### PR TITLE
feat: strategy-based scanner with multi-agent support

### DIFF
--- a/scripts/wrap.sh
+++ b/scripts/wrap.sh
@@ -20,7 +20,13 @@ TERMINAL_JSON=$(bash "$SCRIPT_DIR/registry.sh" 2>/dev/null)
 [ -z "$TERMINAL_JSON" ] && TERMINAL_JSON='{"kind":"unknown","focus_id":"'$$'","outer_id":"","label":"Terminal"}'
 
 # Input detection patterns (ERE)
+# Generic prompts
 INPUT_PAT='\? $|\? .*\[|\[y/n\]|\[Y/n\]|\[yes/no\]|password:|Password:|passphrase:|Passphrase:|Enter to|Press .* to|Overwrite\?|Continue\?|Confirm\?|Proceed\?|Are you sure'
+# Claude Code specific: permission prompts, tool approval
+INPUT_PAT="$INPUT_PAT|Allow |Deny |approve|Yes, allow|No, deny|Do you want to|permission"
+# Codex specific (future-proof)
+INPUT_PAT="$INPUT_PAT|APPROVE|DENY|approve changes"
+# User-supplied extra patterns
 [ -n "${INPUT_EXTRA:-}" ] && INPUT_PAT="$INPUT_PAT|$INPUT_EXTRA"
 
 # JSON-encode a string value (proper escaping of \, ", control chars)

--- a/src-tauri/src/focusers/macos_app.rs
+++ b/src-tauri/src/focusers/macos_app.rs
@@ -1,7 +1,8 @@
 /// Activates a macOS terminal window using AppleScript.
 /// `focus_id` is the application name (e.g. "iTerm2", "Terminal").
+/// `outer_id` is the TTY name (e.g. "ttys000") for tab-specific focus.
 
-pub fn focus(focus_id: &str, _outer_id: &str) -> Result<(), String> {
+pub fn focus(focus_id: &str, outer_id: &str) -> Result<(), String> {
     if focus_id.is_empty() {
         return Ok(());
     }
@@ -10,17 +11,57 @@ pub fn focus(focus_id: &str, _outer_id: &str) -> Result<(), String> {
     {
         use super::os_helpers::spawn_silent;
 
-        // Activate the application by name via AppleScript
-        let script = format!(
-            "tell application \"{}\" to activate",
-            focus_id.replace('\\', "\\\\").replace('"', "\\\"")
-        );
+        // If we have a TTY, try tab-specific focus via terminal's AppleScript API
+        if !outer_id.is_empty() {
+            let script = match focus_id {
+                "iTerm2" => Some(format!(
+                    r#"tell application "iTerm2"
+                        activate
+                        repeat with w in windows
+                            repeat with t in tabs of w
+                                repeat with s in sessions of t
+                                    if tty of s contains "{}" then
+                                        select s
+                                        return
+                                    end if
+                                end repeat
+                            end repeat
+                        end repeat
+                    end tell"#,
+                    outer_id
+                )),
+                "Terminal" => Some(format!(
+                    r#"tell application "Terminal"
+                        activate
+                        repeat with w in windows
+                            repeat with t in tabs of w
+                                if tty of t contains "{}" then
+                                    set selected tab of w to t
+                                    set index of w to 1
+                                    return
+                                end if
+                            end repeat
+                        end repeat
+                    end tell"#,
+                    outer_id
+                )),
+                _ => None,
+            };
+
+            if let Some(script) = script {
+                return spawn_silent("osascript", &["-e", &script]);
+            }
+        }
+
+        // Fallback: just activate the app
+        let app = focus_id.replace('\\', "\\\\").replace('"', "\\\"");
+        let script = format!("tell application \"{}\" to activate", app);
         spawn_silent("osascript", &["-e", &script])?;
     }
 
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = focus_id;
+        let _ = (focus_id, outer_id);
         log::debug!("macos_app focus is only supported on macOS");
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 
 mod focus;
 mod focusers;
+mod notifier;
 mod scanner;
 mod tray;
 mod watcher;
@@ -29,6 +30,7 @@ fn main() {
             // Spawn watcher on a dedicated OS thread (blocking loop)
             let h_watch = handle.clone();
             std::thread::spawn(move || watcher::watch(h_watch));
+
 
             // Build tray menu (required for AppIndicator on GNOME to show icon;
             // GNOME AppIndicator does NOT support direct click events — only menu)

--- a/src-tauri/src/notifier.rs
+++ b/src-tauri/src/notifier.rs
@@ -1,0 +1,180 @@
+use crate::watcher::AgentStatus;
+
+/// Events that can trigger a notification.
+#[derive(Debug, Clone)]
+pub enum AgentEvent {
+    NeedsInput { agent_name: String },
+}
+
+/// Swappable notification backend.
+pub trait Notifier: Send + Sync {
+    fn notify(&self, event: &AgentEvent);
+}
+
+/// Plays a platform system sound via shell commands.
+pub struct SystemBeepNotifier;
+
+impl Notifier for SystemBeepNotifier {
+    fn notify(&self, event: &AgentEvent) {
+        match event {
+            AgentEvent::NeedsInput { agent_name } => {
+                log::info!("Agent '{}' needs input — playing alert", agent_name);
+                play_system_beep();
+            }
+        }
+    }
+}
+
+fn play_system_beep() {
+    std::thread::spawn(|| {
+        if let Err(e) = platform_beep() {
+            log::warn!("Failed to play notification sound: {}", e);
+        }
+    });
+}
+
+#[cfg(target_os = "linux")]
+fn platform_beep() -> Result<(), String> {
+    use std::process::Command;
+
+    let sounds = [
+        "/usr/share/sounds/freedesktop/stereo/bell.oga",
+        "/usr/share/sounds/freedesktop/stereo/complete.oga",
+    ];
+    for path in &sounds {
+        if std::path::Path::new(path).exists() {
+            if Command::new("paplay").arg(path).output().is_ok() {
+                return Ok(());
+            }
+        }
+    }
+    // Last resort
+    Command::new("sh")
+        .args(["-c", "printf '\\a'"])
+        .output()
+        .map(|_| ())
+        .map_err(|e| format!("beep failed: {}", e))
+}
+
+#[cfg(target_os = "macos")]
+fn platform_beep() -> Result<(), String> {
+    use std::process::Command;
+    Command::new("afplay")
+        .arg("/System/Library/Sounds/Glass.aiff")
+        .output()
+        .map(|_| ())
+        .map_err(|e| format!("afplay failed: {}", e))
+}
+
+#[cfg(target_os = "windows")]
+fn platform_beep() -> Result<(), String> {
+    use std::process::Command;
+    Command::new("powershell")
+        .args(["-c", "[System.Media.SystemSounds]::Exclamation.Play()"])
+        .output()
+        .map(|_| ())
+        .map_err(|e| format!("powershell beep failed: {}", e))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn platform_beep() -> Result<(), String> {
+    log::debug!("No platform beep implementation for this OS");
+    Ok(())
+}
+
+/// Compare old and new agent lists; fire notifications for transitions to needs-input.
+/// Uses `id` for identity matching so title/name changes don't retrigger alerts.
+pub fn detect_and_notify(old: &[AgentStatus], new: &[AgentStatus], notifier: &dyn Notifier) {
+    for agent in new {
+        if agent.status != "needs-input" {
+            continue;
+        }
+        let was_needs_input = old
+            .iter()
+            .find(|a| a.id == agent.id)
+            .map(|a| a.status == "needs-input")
+            .unwrap_or(false);
+
+        if !was_needs_input {
+            notifier.notify(&AgentEvent::NeedsInput {
+                agent_name: agent.name.clone(),
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingNotifier(AtomicUsize);
+    impl Notifier for CountingNotifier {
+        fn notify(&self, _event: &AgentEvent) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn agent(name: &str, status: &str) -> AgentStatus {
+        AgentStatus {
+            id: format!("test:{}", name),
+            name: name.into(),
+            status: status.into(),
+            message: String::new(),
+            terminal: None,
+            can_focus: false,
+            cpu: None,
+        }
+    }
+
+    #[test]
+    fn no_notification_when_already_needs_input() {
+        let n = CountingNotifier(AtomicUsize::new(0));
+        let old = vec![agent("a", "needs-input")];
+        let new = vec![agent("a", "needs-input")];
+        detect_and_notify(&old, &new, &n);
+        assert_eq!(n.0.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn notification_on_transition_to_needs_input() {
+        let n = CountingNotifier(AtomicUsize::new(0));
+        let old = vec![agent("a", "working")];
+        let new = vec![agent("a", "needs-input")];
+        detect_and_notify(&old, &new, &n);
+        assert_eq!(n.0.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn notification_for_new_agent_as_needs_input() {
+        let n = CountingNotifier(AtomicUsize::new(0));
+        detect_and_notify(&[], &[agent("a", "needs-input")], &n);
+        assert_eq!(n.0.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn no_notification_for_non_needs_input() {
+        let n = CountingNotifier(AtomicUsize::new(0));
+        let old = vec![agent("a", "idle")];
+        let new = vec![agent("a", "working")];
+        detect_and_notify(&old, &new, &n);
+        assert_eq!(n.0.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn multiple_agents_only_transitioned_ones_notify() {
+        let n = CountingNotifier(AtomicUsize::new(0));
+        let old = vec![
+            agent("a", "working"),
+            agent("b", "needs-input"),
+            agent("c", "idle"),
+        ];
+        let new = vec![
+            agent("a", "needs-input"),
+            agent("b", "needs-input"),
+            agent("c", "needs-input"),
+        ];
+        detect_and_notify(&old, &new, &n);
+        assert_eq!(n.0.load(Ordering::Relaxed), 2);
+    }
+}

--- a/src-tauri/src/scanner/linux.rs
+++ b/src-tauri/src/scanner/linux.rs
@@ -2,8 +2,13 @@ use std::path::{Path, PathBuf};
 
 use crate::watcher::TerminalInfo;
 use super::{known_terminal, ProcInfo, WindowCache};
+use super::strategies::CliStrategy;
 
-pub fn find_cli_processes() -> Vec<ProcInfo> {
+/// Find CLI processes matching any registered strategy.
+/// Returns each process paired with a reference to the strategy that matched it.
+pub fn find_cli_processes<'a>(
+    strategies: &'a [Box<dyn CliStrategy>],
+) -> Vec<(ProcInfo, &'a dyn CliStrategy)> {
     let mut out = Vec::new();
     let proc_dir = match std::fs::read_dir("/proc") {
         Ok(d) => d,
@@ -32,12 +37,17 @@ pub fn find_cli_processes() -> Vec<ProcInfo> {
             .and_then(|n| n.to_str())
             .unwrap_or("");
 
-        if exe_name != "claude" {
-            continue;
-        }
+        // Match against registered strategies
+        let strategy = match strategies.iter().find(|s| {
+            s.process_names().iter().any(|n| *n == exe_name)
+        }) {
+            Some(s) => s.as_ref(),
+            None => continue,
+        };
 
+        // Check exclusions
         let full = String::from_utf8_lossy(&cmdline);
-        if full.contains("mcp-server") || full.contains("worker-service") {
+        if strategy.excluded_substrings().iter().any(|exc| full.contains(exc)) {
             continue;
         }
 
@@ -76,7 +86,7 @@ pub fn find_cli_processes() -> Vec<ProcInfo> {
             .unwrap_or(&tty_path)
             .to_string();
 
-        out.push(ProcInfo {
+        out.push((ProcInfo {
             pid,
             ppid,
             cwd,
@@ -84,7 +94,9 @@ pub fn find_cli_processes() -> Vec<ProcInfo> {
             utime,
             stime,
             instant_cpu: None,
-        });
+            window_title: None,
+            last_active: None,
+        }, strategy));
     }
 
     out
@@ -99,7 +111,10 @@ pub fn terminal_info(cache: &mut WindowCache, p: &ProcInfo) -> Option<TerminalIn
         if cur <= 1 {
             break;
         }
-        let cmdline = std::fs::read_to_string(format!("/proc/{}/cmdline", cur)).ok()?;
+        let cmdline = match std::fs::read_to_string(format!("/proc/{}/cmdline", cur)) {
+            Ok(s) => s,
+            Err(_) => break,
+        };
         let exe = cmdline.split('\0').next().unwrap_or("");
         let exe_name = Path::new(exe)
             .file_name()
@@ -112,11 +127,17 @@ pub fn terminal_info(cache: &mut WindowCache, p: &ProcInfo) -> Option<TerminalIn
             break;
         }
 
-        // Go up
-        let stat = std::fs::read_to_string(format!("/proc/{}/stat", cur)).ok()?;
-        let close = stat.rfind(')')?;
-        let fields: Vec<&str> = stat[close + 2..].split_whitespace().collect();
-        cur = fields.get(1)?.parse().ok()?;
+        // Go up — break instead of bail if parent is unreadable
+        let next_pid = (|| -> Option<u32> {
+            let stat = std::fs::read_to_string(format!("/proc/{}/stat", cur)).ok()?;
+            let close = stat.rfind(')')?;
+            let fields: Vec<&str> = stat[close + 2..].split_whitespace().collect();
+            fields.get(1)?.parse().ok()
+        })();
+        match next_pid {
+            Some(p) => cur = p,
+            None => break,
+        }
     }
 
     if term_pid == 0 {
@@ -136,7 +157,7 @@ pub fn terminal_info(cache: &mut WindowCache, p: &ProcInfo) -> Option<TerminalIn
     let focus_id = if has_display {
         cache
             .entry(term_pid)
-            .or_insert_with(|| xdotool_search_pid(term_pid))
+            .or_insert_with(|| find_window_for_pid(term_pid))
             .clone()
             .unwrap_or_default()
     } else {
@@ -165,6 +186,37 @@ fn xdotool_get_name(wid_hex: &str) -> Option<String> {
         .ok()?;
     let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if name.is_empty() { None } else { Some(name) }
+}
+
+/// Search for an X11 window owned by `start_pid`, walking up parent chain
+/// if the initial PID has no window. Handles multi-process terminals like Warp
+/// where the detected "warp" server (child) has no window but its parent
+/// "warp-terminal" (GUI process) owns the actual X11 window.
+fn find_window_for_pid(start_pid: u32) -> Option<String> {
+    let mut pid = start_pid;
+    for _ in 0..3 {
+        if pid <= 1 {
+            break;
+        }
+        if let Some(wid) = xdotool_search_pid(pid) {
+            return Some(wid);
+        }
+        // Walk to parent
+        let stat = match std::fs::read_to_string(format!("/proc/{}/stat", pid)) {
+            Ok(s) => s,
+            Err(_) => break,
+        };
+        let close = match stat.rfind(')') {
+            Some(i) => i,
+            None => break,
+        };
+        let fields: Vec<&str> = stat[close + 2..].split_whitespace().collect();
+        pid = match fields.get(1).and_then(|s| s.parse().ok()) {
+            Some(p) => p,
+            None => break,
+        };
+    }
+    None
 }
 
 fn xdotool_search_pid(pid: u32) -> Option<String> {

--- a/src-tauri/src/scanner/macos.rs
+++ b/src-tauri/src/scanner/macos.rs
@@ -2,8 +2,12 @@ use std::path::{Path, PathBuf};
 
 use crate::watcher::TerminalInfo;
 use super::{known_terminal, ProcInfo, WindowCache};
+use super::strategies::CliStrategy;
 
-pub fn find_cli_processes() -> Vec<ProcInfo> {
+/// Find CLI processes matching any registered strategy.
+pub fn find_cli_processes<'a>(
+    strategies: &'a [Box<dyn CliStrategy>],
+) -> Vec<(ProcInfo, &'a dyn CliStrategy)> {
     let output = match std::process::Command::new("ps")
         .args(["-eo", "pid,ppid,pcpu,tty,command"])
         .output()
@@ -27,12 +31,15 @@ pub fn find_cli_processes() -> Vec<ProcInfo> {
             .and_then(|n| n.to_str())
             .unwrap_or("");
 
-        if exe_name != "claude" {
-            continue;
-        }
+        let strategy = match strategies.iter().find(|s| {
+            s.process_names().iter().any(|n| *n == exe_name)
+        }) {
+            Some(s) => s.as_ref(),
+            None => continue,
+        };
 
         let full_cmd = parts[4..].join(" ");
-        if full_cmd.contains("mcp-server") || full_cmd.contains("worker-service") {
+        if strategy.excluded_substrings().iter().any(|exc| full_cmd.contains(exc)) {
             continue;
         }
 
@@ -48,14 +55,16 @@ pub fn find_cli_processes() -> Vec<ProcInfo> {
             parts[3].to_string()
         };
 
-        // Get CWD via lsof
-        let cwd = lsof_cwd(pid).unwrap_or_else(|| PathBuf::from("/"));
+        // Get CWD via lsof, fall back to PWD from process environment
+        let cwd = lsof_cwd(pid)
+            .or_else(|| env_cwd(pid))
+            .unwrap_or_else(|| PathBuf::from("/"));
 
         if tty_label.is_empty() {
             continue; // skip non-terminal processes
         }
 
-        out.push(ProcInfo {
+        out.push((ProcInfo {
             pid,
             ppid,
             cwd,
@@ -63,7 +72,9 @@ pub fn find_cli_processes() -> Vec<ProcInfo> {
             utime: 0,
             stime: 0,
             instant_cpu: Some(cpu),
-        });
+            window_title: None,
+            last_active: None,
+        }, strategy));
     }
 
     out
@@ -107,10 +118,16 @@ pub fn terminal_info(cache: &mut WindowCache, p: &ProcInfo) -> Option<TerminalIn
         term_app = p.tty_label.clone();
     }
 
-    let window_title = if term_pid > 0 {
+    // Use TTY-based AppleScript for precise window title (works without
+    // Accessibility permissions), then fall back to System Events.
+    let tty = &p.tty_label;
+    let window_title = if !term_app.is_empty() && term_app != *tty {
         cache
             .entry(term_pid)
-            .or_insert_with(|| osascript_window_title(term_pid))
+            .or_insert_with(|| {
+                tty_window_title(&term_app, tty)
+                    .or_else(|| osascript_window_title(term_pid))
+            })
             .clone()
     } else {
         None
@@ -119,7 +136,7 @@ pub fn terminal_info(cache: &mut WindowCache, p: &ProcInfo) -> Option<TerminalIn
     Some(TerminalInfo {
         kind: "macos_app".to_string(),
         focus_id: term_app.clone(),
-        outer_id: String::new(),
+        outer_id: tty.clone(), // TTY for tab-specific focus
         label: term_app,
         window_title,
     })
@@ -127,7 +144,7 @@ pub fn terminal_info(cache: &mut WindowCache, p: &ProcInfo) -> Option<TerminalIn
 
 fn lsof_cwd(pid: u32) -> Option<PathBuf> {
     let output = std::process::Command::new("lsof")
-        .args(["-p", &pid.to_string(), "-d", "cwd", "-Fn"])
+        .args(["-p", &pid.to_string(), "-a", "-d", "cwd", "-Fn"])
         .output()
         .ok()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -137,6 +154,65 @@ fn lsof_cwd(pid: u32) -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// Fallback CWD detection: read PWD from process environment via `ps eww`.
+fn env_cwd(pid: u32) -> Option<PathBuf> {
+    let output = std::process::Command::new("ps")
+        .args(["eww", "-p", &pid.to_string(), "-o", "command="])
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for part in stdout.split_whitespace() {
+        if let Some(pwd) = part.strip_prefix("PWD=") {
+            let path = PathBuf::from(pwd);
+            if path.is_absolute() {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+/// Get window title using terminal-specific AppleScript keyed by TTY.
+/// More reliable than System Events (doesn't need Accessibility permissions)
+/// and finds the exact tab, not just the front window.
+fn tty_window_title(app_name: &str, tty: &str) -> Option<String> {
+    let script = match app_name {
+        "iTerm2" => format!(
+            r#"tell application "iTerm2"
+                repeat with w in windows
+                    repeat with t in tabs of w
+                        repeat with s in sessions of t
+                            if tty of s contains "{}" then
+                                return name of w
+                            end if
+                        end repeat
+                    end repeat
+                end repeat
+            end tell"#,
+            tty
+        ),
+        "Terminal" => format!(
+            r#"tell application "Terminal"
+                repeat with w in windows
+                    repeat with t in tabs of w
+                        if tty of t contains "{}" then
+                            return name of w
+                        end if
+                    end repeat
+                end repeat
+            end tell"#,
+            tty
+        ),
+        _ => return None,
+    };
+    let output = std::process::Command::new("osascript")
+        .args(["-e", &script])
+        .output()
+        .ok()?;
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if name.is_empty() { None } else { Some(name) }
 }
 
 fn osascript_window_title(term_pid: u32) -> Option<String> {

--- a/src-tauri/src/scanner/mod.rs
+++ b/src-tauri/src/scanner/mod.rs
@@ -4,6 +4,8 @@ use std::time::Instant;
 
 use crate::watcher::AgentStatus;
 
+pub mod strategies;
+
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "macos")]
@@ -28,26 +30,26 @@ struct CpuSnapshot {
 /// Per-terminal-PID cache for window IDs (shared across platforms).
 type WindowCache = HashMap<u32, Option<String>>;
 
-/// Scans for live Claude CLI processes across platforms.
+/// Scans for live CLI agent processes across platforms.
 pub struct Scanner {
     prev: HashMap<u32, CpuSnapshot>,
     window_cache: WindowCache,
+    strategies: Vec<Box<dyn strategies::CliStrategy>>,
 }
 
-/// Seconds after last activity before we consider the agent "idle"
-/// rather than "needs-input". If Claude was recently working and is
-/// now quiet, it's likely waiting for user approval/input.
-const NEEDS_INPUT_WINDOW_SECS: u64 = 120;
-
-struct ProcInfo {
-    pid: u32,
-    ppid: u32,
-    cwd: PathBuf,
-    tty_label: String,
-    utime: u64,
-    stime: u64,
+pub struct ProcInfo {
+    pub pid: u32,
+    pub ppid: u32,
+    pub cwd: PathBuf,
+    pub tty_label: String,
+    pub utime: u64,
+    pub stime: u64,
     /// Pre-computed CPU% (macOS `ps` gives this directly).
-    instant_cpu: Option<f64>,
+    pub instant_cpu: Option<f64>,
+    /// Terminal window title (populated by platform terminal_info).
+    pub window_title: Option<String>,
+    /// Last time this process had significant CPU activity (carried from snapshot).
+    pub last_active: Option<Instant>,
 }
 
 impl Scanner {
@@ -55,43 +57,32 @@ impl Scanner {
         Self {
             prev: HashMap::new(),
             window_cache: HashMap::new(),
+            strategies: strategies::all_strategies(),
         }
     }
 
     pub fn scan(&mut self) -> Vec<AgentStatus> {
-        let procs = platform::find_cli_processes();
+        let procs = platform::find_cli_processes(&self.strategies);
         let mut agents = Vec::new();
         let mut seen = std::collections::HashSet::new();
 
-        for p in &procs {
+        for (mut p, strategy) in procs {
             seen.insert(p.pid);
 
-            let cpu_pct = self.cpu_pct(p);
+            let cpu_pct = self.cpu_pct(&p);
             let is_active = cpu_pct > 2.0;
 
-            // Carry forward last_active from previous snapshot
+            // Carry forward last_active from previous snapshot.
+            // New processes start with last_active = now so they default
+            // to "needs-input" rather than "idle" on first scan.
+            let is_new = !self.prev.contains_key(&p.pid);
             let prev_last_active = self.prev.get(&p.pid).and_then(|s| s.last_active);
-            let last_active = if is_active {
+            let last_active = if is_active || is_new {
                 Some(Instant::now())
             } else {
                 prev_last_active
             };
-
-            // Determine status:
-            //  - High CPU → working
-            //  - Low CPU, was recently active → needs-input (waiting for approval)
-            //  - Low CPU, idle for a while → idle
-            let status = if is_active {
-                "working"
-            } else if let Some(t) = last_active {
-                if t.elapsed().as_secs() < NEEDS_INPUT_WINDOW_SECS {
-                    "needs-input"
-                } else {
-                    "idle"
-                }
-            } else {
-                "idle"
-            };
+            p.last_active = last_active;
 
             let project = p
                 .cwd
@@ -99,12 +90,21 @@ impl Scanner {
                 .and_then(|n| n.to_str())
                 .unwrap_or("unknown");
 
-            // Get terminal info first so we can use window title in the name
-            let terminal = platform::terminal_info(&mut self.window_cache, p);
+            // Get terminal info and populate window_title on ProcInfo
+            let terminal = platform::terminal_info(&mut self.window_cache, &p);
+            if let Some(ref t) = terminal {
+                if p.window_title.is_none() {
+                    p.window_title = t.window_title.clone();
+                }
+            }
 
-            // Build a display suffix for the agent name.
-            // Window titles are unique per window; when unavailable,
-            // combine terminal label + tty for disambiguation.
+            // Count direct child processes for the strategy
+            let child_count = count_children(p.pid);
+
+            // Delegate state detection to the strategy
+            let detected = strategy.detect_state(&p, cpu_pct, child_count);
+
+            // Build display name
             let suffix = if let Some(ref t) = terminal {
                 if let Some(ref wt) = t.window_title {
                     wt.clone()
@@ -125,23 +125,21 @@ impl Scanner {
                 format!("{} · {}", project, &suffix)
             };
 
-            let message = match status {
-                "working" => format!("Active ({:.0}% CPU)", cpu_pct),
-                "needs-input" => "Waiting for input".to_string(),
-                _ => p.cwd.display().to_string(),
-            };
-
             let can_focus = terminal
                 .as_ref()
                 .map(|t| !t.focus_id.is_empty())
                 .unwrap_or(false);
 
+            let id = format!("scan:{}", p.tty_label);
+
             agents.push(AgentStatus {
+                id,
                 name,
-                status: status.to_string(),
-                message,
+                status: detected.status,
+                message: detected.message,
                 terminal,
                 can_focus,
+                cpu: Some(cpu_pct),
             });
 
             self.prev.insert(
@@ -174,6 +172,38 @@ impl Scanner {
         let clk_tck = clk_tck() as f64;
         (delta / clk_tck / dt) * 100.0
     }
+}
+
+/// Count direct child processes of a given PID.
+#[cfg(target_os = "linux")]
+fn count_children(pid: u32) -> u32 {
+    let task_dir = format!("/proc/{}/task/{}/children", pid, pid);
+    std::fs::read_to_string(&task_dir)
+        .map(|s| s.split_whitespace().count() as u32)
+        .unwrap_or(0)
+}
+
+#[cfg(target_os = "macos")]
+fn count_children(pid: u32) -> u32 {
+    std::process::Command::new("pgrep")
+        .args(["-P", &pid.to_string()])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).lines().count() as u32)
+        .unwrap_or(0)
+}
+
+#[cfg(target_os = "windows")]
+fn count_children(pid: u32) -> u32 {
+    std::process::Command::new("wmic")
+        .args(["process", "where", &format!("ParentProcessId={}", pid), "get", "ProcessId", "/FORMAT:CSV"])
+        .output()
+        .map(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .filter(|l| !l.trim().is_empty() && !l.contains("Node"))
+                .count() as u32
+        })
+        .unwrap_or(0)
 }
 
 /// Returns the kernel clock ticks per second (CLK_TCK).
@@ -249,4 +279,10 @@ mod tests {
         let _agents = s.scan();
     }
 
+    #[test]
+    fn all_strategies_contains_claude() {
+        let strats = strategies::all_strategies();
+        assert!(!strats.is_empty());
+        assert!(strats[0].process_names().contains(&"claude"));
+    }
 }

--- a/src-tauri/src/scanner/strategies/claude_code.rs
+++ b/src-tauri/src/scanner/strategies/claude_code.rs
@@ -1,0 +1,197 @@
+use super::{CliStrategy, DetectedState};
+use crate::scanner::ProcInfo;
+
+pub struct ClaudeCodeStrategy;
+
+/// Seconds after last high-CPU burst before we fall back to "idle".
+const NEEDS_INPUT_WINDOW_SECS: u64 = 120;
+
+impl CliStrategy for ClaudeCodeStrategy {
+    fn process_names(&self) -> &[&str] {
+        &["claude"]
+    }
+
+    fn excluded_substrings(&self) -> &[&str] {
+        &["mcp-server", "worker-service"]
+    }
+
+    fn detect_state(&self, info: &ProcInfo, cpu_pct: f64, child_count: u32) -> DetectedState {
+        // Signal 1: Window title patterns (highest confidence).
+        // Claude Code sets terminal title; some terminals expose it.
+        if let Some(ref title) = info.window_title {
+            if let Some(state) = detect_from_title(title) {
+                return state;
+            }
+        }
+
+        // Signal 2: Child processes — if claude spawned subprocesses
+        // (bash, git, npm, cargo, etc.), it's executing a tool.
+        if child_count > 0 && cpu_pct > 0.5 {
+            return DetectedState {
+                status: "working".to_string(),
+                message: format!("Running tool ({} subprocess{})", child_count, if child_count == 1 { "" } else { "es" }),
+                confidence: 0.75,
+            };
+        }
+
+        // Signal 3: CPU heuristic (fallback).
+        let is_active = cpu_pct > 2.0;
+
+        if is_active {
+            DetectedState {
+                status: "working".to_string(),
+                message: format!("Active ({:.0}% CPU)", cpu_pct),
+                confidence: 0.5,
+            }
+        } else if let Some(t) = info.last_active {
+            if t.elapsed().as_secs() < NEEDS_INPUT_WINDOW_SECS {
+                DetectedState {
+                    status: "needs-input".to_string(),
+                    message: "Waiting for input".to_string(),
+                    confidence: 0.4,
+                }
+            } else {
+                DetectedState {
+                    status: "idle".to_string(),
+                    message: info.cwd.display().to_string(),
+                    confidence: 0.4,
+                }
+            }
+        } else {
+            DetectedState {
+                status: "idle".to_string(),
+                message: info.cwd.display().to_string(),
+                confidence: 0.3,
+            }
+        }
+    }
+
+    fn tool_label(&self) -> &str {
+        "Claude Code"
+    }
+}
+
+/// Try to infer state from the terminal window title.
+/// Claude Code updates the terminal title during operation.
+fn detect_from_title(title: &str) -> Option<DetectedState> {
+    let lower = title.to_lowercase();
+
+    // Claude Code shows "Claude Code" or task description in title.
+    // When waiting for input, the prompt indicator appears.
+    // When working, tool names or "thinking" may appear.
+
+    // Patterns observed: title often contains the prompt "❯" when idle/waiting
+    if lower.contains("waiting") || lower.contains("approve") || lower.contains("allow") {
+        return Some(DetectedState {
+            status: "needs-input".to_string(),
+            message: truncate(title, 120),
+            confidence: 0.9,
+        });
+    }
+
+    if lower.contains("running") || lower.contains("editing") || lower.contains("thinking") {
+        return Some(DetectedState {
+            status: "working".to_string(),
+            message: truncate(title, 120),
+            confidence: 0.9,
+        });
+    }
+
+    None
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        match s.char_indices().nth(max) {
+            Some((idx, _)) => s[..idx].to_string(),
+            None => s.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    fn make_info(title: Option<&str>, last_active: Option<Instant>) -> ProcInfo {
+        ProcInfo {
+            pid: 1000,
+            ppid: 999,
+            cwd: PathBuf::from("/home/user/project"),
+            tty_label: "pts/1".to_string(),
+            utime: 0,
+            stime: 0,
+            instant_cpu: None,
+            window_title: title.map(|s| s.to_string()),
+            last_active,
+        }
+    }
+
+    #[test]
+    fn high_cpu_means_working() {
+        let strategy = ClaudeCodeStrategy;
+        let info = make_info(None, None);
+        let state = strategy.detect_state(&info, 15.0, 0);
+        assert_eq!(state.status, "working");
+    }
+
+    #[test]
+    fn low_cpu_recently_active_means_needs_input() {
+        let strategy = ClaudeCodeStrategy;
+        let info = make_info(None, Some(Instant::now()));
+        let state = strategy.detect_state(&info, 0.5, 0);
+        assert_eq!(state.status, "needs-input");
+    }
+
+    #[test]
+    fn low_cpu_long_idle_means_idle() {
+        let strategy = ClaudeCodeStrategy;
+        let info = make_info(None, None);
+        let state = strategy.detect_state(&info, 0.5, 0);
+        assert_eq!(state.status, "idle");
+    }
+
+    #[test]
+    fn child_processes_means_working() {
+        let strategy = ClaudeCodeStrategy;
+        let info = make_info(None, None);
+        let state = strategy.detect_state(&info, 1.0, 2);
+        assert_eq!(state.status, "working");
+        assert!(state.message.contains("subprocess"));
+    }
+
+    #[test]
+    fn title_with_waiting_means_needs_input() {
+        let strategy = ClaudeCodeStrategy;
+        let info = make_info(Some("Claude Code - Waiting for approval"), None);
+        let state = strategy.detect_state(&info, 10.0, 0);
+        assert_eq!(state.status, "needs-input");
+        assert!(state.confidence > 0.8);
+    }
+
+    #[test]
+    fn title_with_running_means_working() {
+        let strategy = ClaudeCodeStrategy;
+        let info = make_info(Some("Claude Code - Running tests"), None);
+        let state = strategy.detect_state(&info, 0.1, 0);
+        assert_eq!(state.status, "working");
+        assert!(state.confidence > 0.8);
+    }
+
+    #[test]
+    fn process_names_match() {
+        let s = ClaudeCodeStrategy;
+        assert!(s.process_names().contains(&"claude"));
+    }
+
+    #[test]
+    fn excluded_substrings_filter() {
+        let s = ClaudeCodeStrategy;
+        assert!(s.excluded_substrings().contains(&"mcp-server"));
+        assert!(s.excluded_substrings().contains(&"worker-service"));
+    }
+}

--- a/src-tauri/src/scanner/strategies/codex.rs
+++ b/src-tauri/src/scanner/strategies/codex.rs
@@ -1,0 +1,75 @@
+use super::{CliStrategy, DetectedState};
+use crate::scanner::ProcInfo;
+
+/// Strategy for OpenAI Codex CLI agent detection.
+pub struct CodexStrategy;
+
+impl CliStrategy for CodexStrategy {
+    fn process_names(&self) -> &[&str] {
+        &["codex"]
+    }
+
+    fn excluded_substrings(&self) -> &[&str] {
+        &[]
+    }
+
+    fn detect_state(&self, info: &ProcInfo, cpu_pct: f64, child_count: u32) -> DetectedState {
+        // Codex uses a similar interactive REPL model.
+        // Child processes indicate tool execution.
+        if child_count > 0 && cpu_pct > 0.5 {
+            return DetectedState {
+                status: "working".to_string(),
+                message: format!("Running tool ({} subprocess{})", child_count, if child_count == 1 { "" } else { "es" }),
+                confidence: 0.7,
+            };
+        }
+
+        if cpu_pct > 2.0 {
+            DetectedState {
+                status: "working".to_string(),
+                message: format!("Active ({:.0}% CPU)", cpu_pct),
+                confidence: 0.5,
+            }
+        } else if let Some(t) = info.last_active {
+            if t.elapsed().as_secs() < 120 {
+                DetectedState {
+                    status: "needs-input".to_string(),
+                    message: "Waiting for input".to_string(),
+                    confidence: 0.4,
+                }
+            } else {
+                DetectedState {
+                    status: "idle".to_string(),
+                    message: info.cwd.display().to_string(),
+                    confidence: 0.3,
+                }
+            }
+        } else {
+            DetectedState {
+                status: "idle".to_string(),
+                message: info.cwd.display().to_string(),
+                confidence: 0.3,
+            }
+        }
+    }
+
+    fn tool_label(&self) -> &str {
+        "Codex"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_names() {
+        let s = CodexStrategy;
+        assert!(s.process_names().contains(&"codex"));
+    }
+
+    #[test]
+    fn tool_label() {
+        assert_eq!(CodexStrategy.tool_label(), "Codex");
+    }
+}

--- a/src-tauri/src/scanner/strategies/gemini.rs
+++ b/src-tauri/src/scanner/strategies/gemini.rs
@@ -1,0 +1,73 @@
+use super::{CliStrategy, DetectedState};
+use crate::scanner::ProcInfo;
+
+/// Strategy for Google Gemini CLI agent detection.
+pub struct GeminiStrategy;
+
+impl CliStrategy for GeminiStrategy {
+    fn process_names(&self) -> &[&str] {
+        &["gemini"]
+    }
+
+    fn excluded_substrings(&self) -> &[&str] {
+        &[]
+    }
+
+    fn detect_state(&self, info: &ProcInfo, cpu_pct: f64, child_count: u32) -> DetectedState {
+        if child_count > 0 && cpu_pct > 0.5 {
+            return DetectedState {
+                status: "working".to_string(),
+                message: format!("Running tool ({} subprocess{})", child_count, if child_count == 1 { "" } else { "es" }),
+                confidence: 0.7,
+            };
+        }
+
+        if cpu_pct > 2.0 {
+            DetectedState {
+                status: "working".to_string(),
+                message: format!("Active ({:.0}% CPU)", cpu_pct),
+                confidence: 0.5,
+            }
+        } else if let Some(t) = info.last_active {
+            if t.elapsed().as_secs() < 120 {
+                DetectedState {
+                    status: "needs-input".to_string(),
+                    message: "Waiting for input".to_string(),
+                    confidence: 0.4,
+                }
+            } else {
+                DetectedState {
+                    status: "idle".to_string(),
+                    message: info.cwd.display().to_string(),
+                    confidence: 0.3,
+                }
+            }
+        } else {
+            DetectedState {
+                status: "idle".to_string(),
+                message: info.cwd.display().to_string(),
+                confidence: 0.3,
+            }
+        }
+    }
+
+    fn tool_label(&self) -> &str {
+        "Gemini"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_names() {
+        let s = GeminiStrategy;
+        assert!(s.process_names().contains(&"gemini"));
+    }
+
+    #[test]
+    fn tool_label() {
+        assert_eq!(GeminiStrategy.tool_label(), "Gemini");
+    }
+}

--- a/src-tauri/src/scanner/strategies/mod.rs
+++ b/src-tauri/src/scanner/strategies/mod.rs
@@ -1,0 +1,51 @@
+mod claude_code;
+mod codex;
+mod gemini;
+
+pub use claude_code::ClaudeCodeStrategy;
+pub use codex::CodexStrategy;
+pub use gemini::GeminiStrategy;
+
+use super::ProcInfo;
+
+/// Result of a CLI strategy's state detection.
+pub struct DetectedState {
+    pub status: String,
+    pub message: String,
+    /// How confident we are (0.0–1.0). Higher-confidence results
+    /// are preferred when multiple signals conflict.
+    #[allow(dead_code)]
+    pub confidence: f32,
+}
+
+/// Trait for CLI-specific agent detection strategies.
+///
+/// Each supported CLI tool (Claude Code, Codex, Gemini, etc.) implements
+/// this trait. The scanner iterates all registered strategies to find
+/// and classify running agent processes.
+pub trait CliStrategy: Send + Sync {
+    /// Executable names to match (e.g., `["claude"]`).
+    fn process_names(&self) -> &[&str];
+
+    /// Substrings in the full command line that disqualify a process
+    /// (e.g., helper processes like `mcp-server`).
+    fn excluded_substrings(&self) -> &[&str];
+
+    /// Determine the agent state from process info.
+    /// `cpu_pct` is pre-computed by the scanner's CPU delta tracker.
+    /// `child_count` is the number of direct child processes.
+    fn detect_state(&self, info: &ProcInfo, cpu_pct: f64, child_count: u32) -> DetectedState;
+
+    /// Human-readable tool label shown in the UI (e.g., "Claude Code").
+    #[allow(dead_code)]
+    fn tool_label(&self) -> &str;
+}
+
+/// Returns all registered CLI strategies.
+pub fn all_strategies() -> Vec<Box<dyn CliStrategy>> {
+    vec![
+        Box::new(ClaudeCodeStrategy),
+        Box::new(CodexStrategy),
+        Box::new(GeminiStrategy),
+    ]
+}

--- a/src-tauri/src/scanner/windows.rs
+++ b/src-tauri/src/scanner/windows.rs
@@ -2,15 +2,33 @@ use std::path::PathBuf;
 
 use crate::watcher::TerminalInfo;
 use super::{known_terminal, ProcInfo, WindowCache};
+use super::strategies::CliStrategy;
 
-pub fn find_cli_processes() -> Vec<ProcInfo> {
+/// Find CLI processes matching any registered strategy.
+pub fn find_cli_processes<'a>(
+    strategies: &'a [Box<dyn CliStrategy>],
+) -> Vec<(ProcInfo, &'a dyn CliStrategy)> {
+    // Build wmic filter for all strategy process names
+    let all_names: Vec<&str> = strategies.iter()
+        .flat_map(|s| s.process_names().iter().copied())
+        .collect();
+    if all_names.is_empty() {
+        return Vec::new();
+    }
+
+    // Query all potential agent processes in one wmic call
+    let name_filter = all_names.iter()
+        .map(|n| format!("name='{}.exe'", n))
+        .collect::<Vec<_>>()
+        .join(" or ");
+
     let output = match std::process::Command::new("wmic")
         .args([
             "process",
             "where",
-            "name='claude.exe'",
+            &name_filter,
             "get",
-            "ProcessId,ParentProcessId,CommandLine",
+            "ProcessId,ParentProcessId,CommandLine,Name",
             "/FORMAT:CSV",
         ])
         .output()
@@ -24,21 +42,30 @@ pub fn find_cli_processes() -> Vec<ProcInfo> {
 
     for line in stdout.lines().skip(1) {
         let cols: Vec<&str> = line.split(',').collect();
-        // CSV format: Node,CommandLine,ParentProcessId,ProcessId
-        if cols.len() < 4 {
+        // CSV format: Node,CommandLine,Name,ParentProcessId,ProcessId
+        if cols.len() < 5 {
             continue;
         }
 
         let cmd_line = cols[1];
-        if cmd_line.contains("mcp-server") || cmd_line.contains("worker-service") {
+        let proc_name = cols[2].trim().strip_suffix(".exe").unwrap_or(cols[2].trim());
+
+        let strategy = match strategies.iter().find(|s| {
+            s.process_names().iter().any(|n| *n == proc_name)
+        }) {
+            Some(s) => s.as_ref(),
+            None => continue,
+        };
+
+        if strategy.excluded_substrings().iter().any(|exc| cmd_line.contains(exc)) {
             continue;
         }
 
-        let pid: u32 = match cols[3].trim().parse() {
+        let pid: u32 = match cols[4].trim().parse() {
             Ok(p) => p,
             Err(_) => continue,
         };
-        let ppid: u32 = cols[2].trim().parse().unwrap_or(0);
+        let ppid: u32 = cols[3].trim().parse().unwrap_or(0);
 
         // CWD is hard to get on Windows without elevated privileges
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("C:\\"));
@@ -46,7 +73,7 @@ pub fn find_cli_processes() -> Vec<ProcInfo> {
         // Get CPU times (100-nanosecond units) via wmic
         let (utime, stime) = wmic_cpu_times(pid);
 
-        out.push(ProcInfo {
+        out.push((ProcInfo {
             pid,
             ppid,
             cwd,
@@ -54,7 +81,9 @@ pub fn find_cli_processes() -> Vec<ProcInfo> {
             utime,
             stime,
             instant_cpu: None,
-        });
+            window_title: None,
+            last_active: None,
+        }, strategy));
     }
 
     out

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -123,7 +123,13 @@ pub fn toggle_popup(app: &AppHandle) {
             }
             let _ = win.show();
             let _ = win.set_focus();
-            // State is pushed to the frontend when it mounts and calls get_agents
+            // Emit after a short delay so the WebView has time to
+            // load and register its event listeners
+            let h = app.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(std::time::Duration::from_millis(500));
+                emit_current_state(&h);
+            });
         }
         Err(e) => log::error!("Failed to create popup window: {}", e),
     }
@@ -173,11 +179,13 @@ mod tests {
 
     fn agent(status: &str) -> AgentStatus {
         AgentStatus {
+            id: "test:0".into(),
             name: "test".into(),
             status: status.into(),
             message: "".into(),
             terminal: None,
             can_focus: false,
+            cpu: None,
         }
     }
 

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
+
+use crate::notifier::SystemBeepNotifier;
 
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
@@ -20,12 +22,18 @@ pub struct TerminalInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentStatus {
+    /// Stable identity for dedup, list keying, and notification tracking.
+    /// For scanned agents: "scan:<tty_label>". For file-backed: "file:<stem>".
+    pub id: String,
     pub name: String,
     pub status: String,
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub terminal: Option<TerminalInfo>,
     pub can_focus: bool,
+    /// CPU usage percentage (None for file-based agents without CPU data).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<f64>,
 }
 
 pub fn status_dir() -> Option<PathBuf> {
@@ -81,12 +89,15 @@ pub fn parse_status_file(path: &Path) -> Option<AgentStatus> {
             .map(|t| !t.focus_id.is_empty() && t.focus_id != "0")
             .unwrap_or(false);
 
+        let id = format!("file:{}", name);
         Some(AgentStatus {
+            id,
             name,
             status,
             message,
             terminal,
             can_focus,
+            cpu: None,
         })
     } else {
         // Legacy pipe format: "status|message"
@@ -94,12 +105,15 @@ pub fn parse_status_file(path: &Path) -> Option<AgentStatus> {
             Some((s, m)) => (s.to_string(), m.to_string()),
             None => (trimmed.to_string(), String::new()),
         };
+        let id = format!("file:{}", name);
         Some(AgentStatus {
+            id,
             name,
             status,
             message,
             terminal: None,
             can_focus: false,
+            cpu: None,
         })
     }
 }
@@ -155,13 +169,19 @@ fn sort_agents(agents: &mut [AgentStatus]) {
 
 /// Cached latest merged agent list for on-demand popup refresh.
 static LATEST_AGENTS: Mutex<Vec<AgentStatus>> = Mutex::new(Vec::new());
+static NOTIFIER: LazyLock<SystemBeepNotifier> = LazyLock::new(|| SystemBeepNotifier);
 
 fn emit_agents(app: &AppHandle, agents: Vec<AgentStatus>) {
+    log::info!("emit_agents: {} agents", agents.len());
+    for a in &agents {
+        log::debug!("  agent: name={:?} status={:?}", a.name, a.status);
+    }
     {
         let mut cache = LATEST_AGENTS.lock().unwrap_or_else(|e| {
             log::warn!("LATEST_AGENTS mutex poisoned, recovering");
             e.into_inner()
         });
+        crate::notifier::detect_and_notify(&cache, &agents, &*NOTIFIER);
         *cache = agents.clone();
     }
     crate::tray::update_icon(app, &agents);
@@ -189,10 +209,12 @@ pub fn get_status_dir() -> String {
 /// Tauri command: return cached agents (called by frontend on mount).
 #[tauri::command]
 pub fn get_agents() -> Vec<AgentStatus> {
-    LATEST_AGENTS.lock().unwrap_or_else(|e| {
+    let agents = LATEST_AGENTS.lock().unwrap_or_else(|e| {
         log::warn!("LATEST_AGENTS mutex poisoned, recovering");
         e.into_inner()
-    }).clone()
+    }).clone();
+    log::info!("get_agents: returning {} agents", agents.len());
+    agents
 }
 
 fn read_and_emit_merged(app: &AppHandle, dir: &Path, scanned: &[AgentStatus]) {
@@ -365,9 +387,9 @@ mod tests {
     #[test]
     fn sort_needs_input_before_working() {
         let mut agents = vec![
-            AgentStatus { name: "b".into(), status: "working".into(), message: "".into(), terminal: None, can_focus: false },
-            AgentStatus { name: "a".into(), status: "needs-input".into(), message: "".into(), terminal: None, can_focus: false },
-            AgentStatus { name: "c".into(), status: "idle".into(), message: "".into(), terminal: None, can_focus: false },
+            AgentStatus { id: "t:b".into(), name: "b".into(), status: "working".into(), message: "".into(), terminal: None, can_focus: false, cpu: None },
+            AgentStatus { id: "t:a".into(), name: "a".into(), status: "needs-input".into(), message: "".into(), terminal: None, can_focus: false, cpu: None },
+            AgentStatus { id: "t:c".into(), name: "c".into(), status: "idle".into(), message: "".into(), terminal: None, can_focus: false, cpu: None },
         ];
         sort_agents(&mut agents);
         assert_eq!(agents[0].status, "needs-input");
@@ -378,6 +400,7 @@ mod tests {
     #[test]
     fn dedup_scanned_when_file_agent_has_same_focus_id() {
         let file_agent = AgentStatus {
+            id: "file:myagent".into(),
             name: "myagent".into(),
             status: "working".into(),
             message: "from wrap.sh".into(),
@@ -389,8 +412,10 @@ mod tests {
                 window_title: None,
             }),
             can_focus: true,
+            cpu: None,
         };
         let scanned_dup = AgentStatus {
+            id: "scan:pts/1".into(),
             name: "Project · Kitty · pts/1".into(),
             status: "idle".into(),
             message: "scanned".into(),
@@ -402,8 +427,10 @@ mod tests {
                 window_title: None,
             }),
             can_focus: true,
+            cpu: None,
         };
         let scanned_unique = AgentStatus {
+            id: "scan:pts/2".into(),
             name: "Other · Alacritty".into(),
             status: "working".into(),
             message: "different".into(),
@@ -415,6 +442,7 @@ mod tests {
                 window_title: None,
             }),
             can_focus: true,
+            cpu: None,
         };
 
         // Simulate what read_and_emit_merged does
@@ -453,4 +481,5 @@ mod tests {
         let result = parse_status_file(f.path()).unwrap();
         assert!(result.message.len() <= 500);
     }
+
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AgentTray",
   "version": "0.1.1",
-  "identifier": "com.agenttray.app",
+  "identifier": "com.sprklai.agenttray",
   "build": {
     "frontendDist": "../build",
     "devUrl": "http://localhost:5173",

--- a/src/lib/components/AgentRow.svelte
+++ b/src/lib/components/AgentRow.svelte
@@ -27,9 +27,15 @@
   </div>
 
   <div class="flex flex-col items-end gap-[3px] flex-shrink-0">
-    <span class="text-[10px] text-[#8a8880] opacity-60 max-w-[100px] truncate text-right" title={agent.terminal?.window_title ?? agent.terminal?.label ?? ''}>
-      {agent.terminal?.window_title ?? agent.terminal?.label ?? ''}
-    </span>
+    {#if agent.cpu != null && agent.cpu > 0}
+      <span class="text-[10px] font-mono text-[#8a8880] opacity-80 tabular-nums">
+        {agent.cpu.toFixed(0)}% CPU
+      </span>
+    {:else}
+      <span class="text-[10px] text-[#8a8880] opacity-60 max-w-[100px] truncate text-right" title={agent.terminal?.window_title ?? agent.terminal?.label ?? ''}>
+        {agent.terminal?.window_title ?? agent.terminal?.label ?? ''}
+      </span>
+    {/if}
     {#if agent.can_focus}
       <button
         type="button"

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,11 +9,13 @@ export interface TerminalInfo {
 }
 
 export interface AgentStatus {
+  id: string;
   name: string;
   status: Status;
   message: string;
   terminal: TerminalInfo | null;
   can_focus: boolean;
+  cpu?: number;
 }
 
 export const STATUS_PRIORITY: Record<Status, number> = {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,31 +13,58 @@
   let agents = $state<AgentStatus[]>([]);
   let pinned = $state(false);
   let statusDir = $state('~/.agent-monitor');
+  let ipcError = $state('');
   let aggregateState = $derived(aggregate(agents));
 
   onMount(() => {
     const cleanups: Array<() => void> = [];
 
     (async () => {
-      // Fetch cached state immediately (no 200ms delay waiting for backend push)
-      agents = await invoke<AgentStatus[]>('get_agents');
-      statusDir = await invoke<string>('get_status_dir') || statusDir;
-
+      // Register listeners FIRST to avoid missing events between
+      // get_agents() and listener registration (race condition fix)
       cleanups.push(await listen<AgentStatus[]>('agents-updated', (event) => {
         agents = event.payload;
+        ipcError = ''; // clear any previous error on successful event
       }));
 
       cleanups.push(await listen<boolean>('pinned-changed', (event) => {
         pinned = event.payload;
       }));
 
+      // Now fetch cached state (listener is already active for any updates)
+      try {
+        const result = await invoke<AgentStatus[]>('get_agents');
+        console.log('[AgentTray] get_agents returned', result.length, 'agents');
+        agents = result;
+      } catch (e) {
+        ipcError = `IPC error: ${e}`;
+        console.error('[AgentTray] get_agents failed:', e);
+      }
+
+      // Retry once if initial fetch returned empty (backend may not have
+      // completed first scan yet on cold start)
+      if (agents.length === 0) {
+        await new Promise(r => setTimeout(r, 600));
+        try {
+          const retry = await invoke<AgentStatus[]>('get_agents');
+          console.log('[AgentTray] retry get_agents returned', retry.length, 'agents');
+          if (retry.length > 0) agents = retry;
+        } catch {}
+      }
+
+      try {
+        statusDir = await invoke<string>('get_status_dir') || statusDir;
+      } catch {}
+
       const win = getCurrentWindow();
       let showTime = Date.now();
 
-      // Track when the window becomes visible so we can ignore
-      // immediate blur events (e.g. from global shortcut toggle)
-      cleanups.push(await listen('tauri://focus', () => {
+      // Re-fetch agents when popup is shown (also works around HMR state loss)
+      cleanups.push(await listen('tauri://focus', async () => {
         showTime = Date.now();
+        try {
+          agents = await invoke<AgentStatus[]>('get_agents');
+        } catch {}
       }));
 
       // Ignore blur events within 300ms of focus — the global shortcut
@@ -96,10 +123,15 @@
     </div>
   </div>
 
-  <!-- Focus error toast -->
+  <!-- Error toasts -->
   {#if focusError}
     <div class="px-3 py-1.5 bg-[#3a2020] border-b border-red-500/20 text-[10px] text-red-400 truncate">
       {focusError}
+    </div>
+  {/if}
+  {#if ipcError}
+    <div class="px-3 py-1.5 bg-[#3a2020] border-b border-red-500/20 text-[10px] text-red-400 truncate">
+      {ipcError}
     </div>
   {/if}
 
@@ -110,7 +142,7 @@
     </p>
   {:else}
     <ul class="py-1 m-0 p-0 glass-scroll" style="max-height: 360px; overflow-y: auto;">
-      {#each agents as agent (agent.name)}
+      {#each agents as agent (agent.id)}
         <AgentRow {agent} onFocus={() => focusAgent(agent)} />
       {/each}
     </ul>


### PR DESCRIPTION
## Summary

- **Scanner refactor**: Replace hardcoded Claude CLI detection with a pluggable `CliStrategy` trait (`strategies/` module), enabling detection of Claude Code, Codex, and Gemini CLI agents
- **Notifier module**: New `notifier.rs` detects agent state transitions (idle/working → needs-input) and triggers system beep alerts
- **macOS tab-specific focus**: Enhanced terminal focuser uses TTY-based AppleScript to find and activate the exact iTerm2/Terminal tab, not just the app
- **Frontend race fix**: Register event listeners before fetching initial state; add retry logic for cold-start; key agent list on stable `id` field instead of `name`
- **AgentStatus enrichment**: Added `id` (stable identity for dedup/keying) and `cpu` (real-time CPU%) fields; UI shows CPU% when active
- **Linux X11 window lookup**: Walk parent process chain for multi-process terminals (e.g., Warp) where the detected process has no X11 window but its parent does
- **wrap.sh**: Added Claude Code and Codex-specific input detection patterns
- **App identifier**: Updated to `com.sprklai.agenttray`

## Test plan

- [ ] Run `cargo test --manifest-path src-tauri/Cargo.toml` — all existing + new strategy tests pass
- [ ] Run `cargo tauri dev` on Linux — verify agents are detected and displayed with CPU%
- [ ] Verify needs-input beep fires when an agent transitions to waiting state
- [ ] Confirm popup opens with agents on first click (no empty flash)
- [ ] Test macOS tab-specific focus with iTerm2 (if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)