### PR TITLE
fix: persist window position on close

### DIFF
--- a/src-tauri/src/heuristics.rs
+++ b/src-tauri/src/heuristics.rs
@@ -5,6 +5,10 @@ use crate::watcher::AgentStatus;
 /// How old a hook status file must be before we consider it stale.
 const STALE_WORKING_TTL: Duration = Duration::from_secs(30);
 
+/// How long a permission_prompt needs-input can stay unacknowledged before
+/// we assume the permission was granted but the follow-up hook didn't fire.
+const STALE_PERMISSION_TTL: Duration = Duration::from_secs(60);
+
 /// CPU threshold below which a "working" hook status is suspect.
 const LOW_CPU_THRESHOLD: f64 = 0.5;
 
@@ -28,8 +32,8 @@ pub fn cross_validate(agents: &mut Vec<AgentStatus>, scanned: &[AgentStatus]) {
             continue;
         }
 
-        // Never override explicit user-facing states
-        if matches!(agent.status.as_str(), "needs-input" | "error") {
+        // "error" is always a definitive state — never override it.
+        if agent.status == "error" {
             continue;
         }
 
@@ -40,6 +44,23 @@ pub fn cross_validate(agents: &mut Vec<AgentStatus>, scanned: &[AgentStatus]) {
         let scan_cpu = scan.cpu.unwrap_or(0.0);
 
         match agent.status.as_str() {
+            // needs-input: never override in general, EXCEPT for stale
+            // permission_prompt entries where the follow-up hook likely
+            // didn't fire (common on macOS after granting permission).
+            "needs-input" => {
+                let is_permission_prompt =
+                    agent.hook_matcher.as_deref() == Some("permission_prompt");
+                if is_permission_prompt {
+                    let is_stale = agent.mtime
+                        .and_then(|mt| now.duration_since(mt).ok())
+                        .map(|age| age > STALE_PERMISSION_TTL)
+                        .unwrap_or(false);
+                    if is_stale && scan_cpu > LOW_CPU_THRESHOLD {
+                        agent.status = "working".to_string();
+                        agent.message = "Running tool...".to_string();
+                    }
+                }
+            }
             "working" | "starting" => {
                 // Stale working: hook says active but process CPU is near-zero
                 // and the status file hasn't been updated recently
@@ -261,5 +282,56 @@ mod tests {
 
         cross_validate(&mut agents, &scanned);
         assert_eq!(agents[0].status, "idle"); // stale + low CPU → downgraded
+    }
+
+    fn hook_agent_with_matcher(
+        status: &str, cli: &str, focus_id: &str,
+        matcher: Option<&str>, mtime: Option<SystemTime>,
+    ) -> AgentStatus {
+        let mut a = hook_agent(status, cli, focus_id, mtime);
+        a.hook_matcher = matcher.map(|s| s.into());
+        a
+    }
+
+    #[test]
+    fn stale_permission_prompt_cleared_when_process_active() {
+        // Simulates macOS case: permission granted, PreToolUse hook didn't fire.
+        let old_mtime = SystemTime::now() - Duration::from_secs(90);
+        let mut agents = vec![hook_agent_with_matcher(
+            "needs-input", "claude-code", "0x1234",
+            Some("permission_prompt"), Some(old_mtime),
+        )];
+        let scanned = vec![scan_agent("claude-code", "0x1234", 3.0)]; // CPU active
+
+        cross_validate(&mut agents, &scanned);
+        assert_eq!(agents[0].status, "working");
+    }
+
+    #[test]
+    fn fresh_permission_prompt_not_cleared() {
+        // Permission prompt is recent — user hasn't responded yet.
+        let fresh_mtime = SystemTime::now();
+        let mut agents = vec![hook_agent_with_matcher(
+            "needs-input", "claude-code", "0x1234",
+            Some("permission_prompt"), Some(fresh_mtime),
+        )];
+        let scanned = vec![scan_agent("claude-code", "0x1234", 3.0)];
+
+        cross_validate(&mut agents, &scanned);
+        assert_eq!(agents[0].status, "needs-input"); // too fresh to clear
+    }
+
+    #[test]
+    fn non_permission_needs_input_never_cleared() {
+        // Other needs-input types (idle_prompt, etc.) are never auto-cleared.
+        let old_mtime = SystemTime::now() - Duration::from_secs(90);
+        let mut agents = vec![hook_agent_with_matcher(
+            "needs-input", "claude-code", "0x1234",
+            Some("idle_prompt"), Some(old_mtime),
+        )];
+        let scanned = vec![scan_agent("claude-code", "0x1234", 3.0)];
+
+        cross_validate(&mut agents, &scanned);
+        assert_eq!(agents[0].status, "needs-input"); // idle_prompt not affected
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -96,7 +96,7 @@ fn main() {
 
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![focus::focus_terminal, watcher::get_agents, watcher::get_status_dir, watcher::install_hooks, tray::toggle_pin])
+        .invoke_handler(tauri::generate_handler![focus::focus_terminal, watcher::get_agents, watcher::get_status_dir, watcher::install_hooks, tray::toggle_pin, tray::close_popup])
         .build(tauri::generate_context!())
         .expect("AgentTray failed to build")
         .run(|_app, event| {

--- a/src-tauri/src/scanner/mod.rs
+++ b/src-tauri/src/scanner/mod.rs
@@ -82,6 +82,18 @@ impl Scanner {
 
     pub fn scan(&mut self) -> Vec<AgentStatus> {
         let procs = platform::find_cli_processes(&self.strategies);
+
+        // Filter out subprocess agents: if a matched process's parent is also a
+        // matched CLI process, it's a subagent or tool child — not a user-level
+        // session. Build the set of all matched PIDs first so transitive
+        // descendants are also caught (child-of-child shares the same set).
+        let matched_pids: std::collections::HashSet<u32> =
+            procs.iter().map(|(p, _)| p.pid).collect();
+        let procs: Vec<_> = procs
+            .into_iter()
+            .filter(|(p, _)| !matched_pids.contains(&p.ppid))
+            .collect();
+
         let mut agents: Vec<AgentStatus> = Vec::new();
         let mut seen = std::collections::HashSet::new();
         // Track which tty_labels we've already emitted to avoid duplicate IDs

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -116,9 +116,10 @@ pub fn toggle_popup(app: &AppHandle) {
         .build()
     {
         Ok(win) => {
-            // Plugin auto-restores saved position on window ready.
-            // For first launch (no saved state), fall back to top-right.
-            position_popup_if_default(app, &win);
+            // Set top-right default in physical pixels; plugin restores saved position
+            // asynchronously on webview ready and will override this.
+            let (default_x, default_y) = compute_default_position(app);
+            let _ = win.set_position(tauri::PhysicalPosition::new(default_x, default_y));
             #[cfg(target_os = "linux")]
             {
                 let _ = std::process::Command::new("wmctrl")
@@ -166,26 +167,18 @@ pub fn hide_popup(app: &AppHandle) {
     }
 }
 
-/// Position the popup at the top-right corner only on first launch
-/// (when the window-state plugin has no saved position).
-fn position_popup_if_default(app: &AppHandle, win: &tauri::WebviewWindow) {
-    // If the plugin restored a saved position, the window won't be at (0,0).
-    if let Ok(pos) = win.outer_position() {
-        if pos.x != 0 || pos.y != 0 {
-            return; // Plugin restored a saved position
-        }
-    }
-    if let Some(monitor) = app
-        .primary_monitor()
+#[tauri::command]
+pub fn close_popup(app: AppHandle) {
+    hide_popup(&app);
+}
+
+fn compute_default_position(app: &AppHandle) -> (i32, i32) {
+    app.primary_monitor()
         .ok()
         .flatten()
         .or_else(|| app.available_monitors().ok().and_then(|m| m.into_iter().next()))
-    {
-        let size = monitor.size();
-        let x = size.width as i32 - 410;
-        let y = 32;
-        let _ = win.set_position(tauri::PhysicalPosition::new(x, y));
-    }
+        .map(|m| (m.size().width as i32 - 410, 32))
+        .unwrap_or((100, 32))
 }
 
 #[cfg(test)]

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -96,7 +96,7 @@
       // toggle causes a brief focus/blur cycle that would immediately hide the popup
       const BLUR_DEBOUNCE_MS = 300;
       cleanups.push(await win.onFocusChanged(({ payload: focused }) => {
-        if (!focused && !pinned && Date.now() - showTime > BLUR_DEBOUNCE_MS) win.hide();
+        if (!focused && !pinned && Date.now() - showTime > BLUR_DEBOUNCE_MS) invoke('close_popup');
       }));
     })();
 
@@ -117,7 +117,7 @@
           outer_id: agent.terminal.outer_id,
         }
       });
-      if (!pinned) getCurrentWindow().hide();
+      if (!pinned) invoke('close_popup');
     } catch (e) {
       focusError = String(e);
       setTimeout(() => { focusError = ''; }, 4000);


### PR DESCRIPTION
## Summary

- **Window position not persisting**: Frontend called `win.hide()` directly in the blur handler and post-agent-focus path, bypassing the Rust `hide_popup()` function that calls `save_window_state`. All dismiss paths now go through a new `close_popup` Tauri command that saves before hiding.
- **Fragile first-launch heuristic**: Replaced `position_popup_if_default` (which checked `pos == (0,0)` and ran before the plugin could restore state) with `compute_default_position` that always sets a physical-pixel top-right default synchronously; the window-state plugin overrides it asynchronously on webview ready with the saved position.
- **Subprocess agent duplicates**: Scanner now filters processes whose parent PID is also a matched CLI process, preventing subagent/tool children from appearing as separate rows.
- **Stale permission_prompt**: Cross-validate now clears `needs-input` with `hook_matcher == "permission_prompt"` when the entry is >60s old and process CPU is active — fixes macOS cases where the follow-up PreToolUse hook doesn't fire after a permission grant.

## Test plan

- [ ] Open popup, drag to a non-default position, click elsewhere to dismiss via blur — reopen should restore dragged position
- [ ] Quit and relaunch app — popup appears at last saved position
- [ ] Tray-click close and "Hide" menu close also preserve position
- [ ] No duplicate agent rows when a CLI spawns subprocesses
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml` passes (3 new heuristics tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)