### PR TITLE
fix: map Stop and idle_prompt to idle instead of needs-input

### DIFF
--- a/scripts/hooks/agent-tray-hook.sh
+++ b/scripts/hooks/agent-tray-hook.sh
@@ -323,10 +323,13 @@ map_claude_code() {
           write_status "needs-input" "Waiting for permission" "$EVENT" "$MATCHER"
           ;;
         idle_prompt)
-          write_status "needs-input" "Waiting for input" "$EVENT" "$MATCHER"
+          write_status "idle" "Waiting for input" "$EVENT" "$MATCHER"
           ;;
         elicitation_dialog)
           write_status "needs-input" "MCP input requested" "$EVENT" "$MATCHER"
+          ;;
+        auth_success)
+          # Auth succeeded — not user-actionable, ignore
           ;;
         *)
           write_status "needs-input" "Notification: ${MATCHER}" "$EVENT" "$MATCHER"
@@ -334,7 +337,7 @@ map_claude_code() {
       esac
       ;;
     Stop)
-      write_status "needs-input" "Waiting for input" "$EVENT"
+      write_status "idle" "Waiting for input" "$EVENT"
       ;;
     StopFailure)
       write_status "error" "API error" "$EVENT"


### PR DESCRIPTION
## Summary

- `Stop` event now writes `idle` status instead of `needs-input` — task completion shows a green dot, not yellow
- `Notification(idle_prompt)` now writes `idle` — Claude being idle is not an actionable state
- `auth_success` notifications are now silently ignored (were incorrectly falling into the `needs-input` wildcard)

## Rationale

`needs-input` (yellow) should only fire when Claude is **blocked** and cannot proceed without user action:
- `permission_prompt` — user must approve a tool call
- `elicitation_dialog` — MCP server needs input

`idle` (green) means Claude finished and is ready for the next prompt — no action required.

## Test plan

- [ ] Complete a task in Claude Code → tray dot turns green after `Stop`
- [ ] Trigger a permission prompt → tray dot turns yellow on `permission_prompt`
- [ ] Verify `~/.agent-monitor/<session>.status` shows `"status":"idle"` after task completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)