### PR TITLE
feat: periodic needs-input reminders, smarter cross-validation, and tmux pane title support

### DIFF
--- a/scripts/hooks/agent-tray-hook.ps1
+++ b/scripts/hooks/agent-tray-hook.ps1
@@ -196,7 +196,7 @@ function Map-Codex {
         'SessionStart'     { Write-Status -Status 'working' -Message 'Session started' -HookEvent $Event }
         'PreToolUse'       { Write-Status -Status 'working' -Message 'Running tool...' -HookEvent $Event -HookMatcher $Matcher }
         'PostToolUse'      { Write-Status -Status 'working' -Message 'Tool completed' -HookEvent $Event -HookMatcher $Matcher }
-        'Stop'             { Write-Status -Status 'idle' -Message 'Finished responding' -HookEvent $Event }
+        'Stop'             { Write-Status -Status 'needs-input' -Message 'Waiting for input' -HookEvent $Event }
         'UserPromptSubmit' { Write-Status -Status 'working' -Message 'Processing prompt' -HookEvent $Event }
         'SessionEnd'       { Remove-StatusFile }
     }

--- a/scripts/hooks/agent-tray-hook.sh
+++ b/scripts/hooks/agent-tray-hook.sh
@@ -440,7 +440,7 @@ map_codex() {
       write_status "working" "Tool completed" "$EVENT" "$MATCHER"
       ;;
     Stop)
-      write_status "idle" "Finished responding" "$EVENT"
+      write_status "needs-input" "Waiting for input" "$EVENT"
       ;;
     UserPromptSubmit)
       write_status "working" "Processing prompt" "$EVENT"

--- a/src-tauri/src/heuristics.rs
+++ b/src-tauri/src/heuristics.rs
@@ -44,23 +44,41 @@ pub fn cross_validate(agents: &mut Vec<AgentStatus>, scanned: &[AgentStatus]) {
 
         let scan_cpu = scan.cpu.unwrap_or(0.0);
 
+        // Scanner-detected waiting states are higher confidence than a stale
+        // hook file saying "working" or "idle", so upgrade immediately.
+        if scan.status == "needs-input" && agent.status != "needs-input" {
+            agent.status = "needs-input".to_string();
+            agent.message = if scan.message.is_empty() {
+                "Waiting for input".to_string()
+            } else {
+                scan.message.clone()
+            };
+            continue;
+        }
+
         match agent.status.as_str() {
-            // needs-input: only permission_prompt and elicitation_dialog are
-            // genuine user-actionable states. All other matchers (unknown
-            // Notification types like quota_warning, context_compact, etc.)
-            // can fire after Stop and spuriously overwrite an idle status —
-            // clear them once stale. Permission prompts are only cleared if
-            // the process has resumed (CPU active), meaning the permission
-            // was silently granted (common on macOS).
+            // needs-input: preserve scanner-confirmed waits and known genuine
+            // hook waits (Codex Stop, Gemini Notification, Claude permission /
+            // elicitation prompts). Only Claude's permission-style waits auto-
+            // resolve when they go stale; non-genuine hook waits are cleared.
             "needs-input" => {
-                let matcher = agent.hook_matcher.as_deref().unwrap_or("");
-                let is_genuine = matcher == "permission_prompt"
-                    || matcher == "elicitation_dialog";
+                if scan.status == "needs-input" {
+                    continue;
+                }
+
+                let is_claude_permission_wait = matches!(
+                    agent.cli.as_deref(),
+                    Some("claude-code")
+                ) && matches!(
+                    agent.hook_matcher.as_deref(),
+                    Some("permission_prompt" | "elicitation_dialog")
+                );
+                let is_genuine = is_genuine_needs_input(agent);
                 let is_stale = agent.mtime
                     .and_then(|mt| now.duration_since(mt).ok())
                     .map(|age| age > STALE_PERMISSION_TTL)
                     .unwrap_or(false);
-                if is_genuine && is_stale {
+                if is_claude_permission_wait && is_stale {
                     if scan_cpu > LOW_CPU_THRESHOLD {
                         // CPU active → permission was silently granted, process resumed
                         agent.status = "working".to_string();
@@ -134,6 +152,18 @@ fn find_scanner_match<'a>(agent: &AgentStatus, scanned: &'a [AgentStatus]) -> Op
     None
 }
 
+fn is_genuine_needs_input(agent: &AgentStatus) -> bool {
+    match agent.cli.as_deref() {
+        Some("claude-code") => matches!(
+            agent.hook_matcher.as_deref(),
+            Some("permission_prompt" | "elicitation_dialog")
+        ),
+        Some("codex") => agent.hook_event.as_deref() == Some("Stop"),
+        Some("gemini") => agent.hook_event.as_deref() == Some("Notification"),
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -163,11 +193,11 @@ mod tests {
         }
     }
 
-    fn scan_agent(cli: &str, focus_id: &str, cpu: f64) -> AgentStatus {
+    fn scan_agent_with_status(cli: &str, focus_id: &str, status: &str, cpu: f64) -> AgentStatus {
         AgentStatus {
             id: format!("scan:pts/1"),
             name: "scan-test".into(),
-            status: "idle".into(),
+            status: status.into(),
             message: "".into(),
             terminal: Some(TerminalInfo {
                 kind: "x11_generic".into(),
@@ -185,6 +215,10 @@ mod tests {
             hook_matcher: None,
             mtime: None,
         }
+    }
+
+    fn scan_agent(cli: &str, focus_id: &str, cpu: f64) -> AgentStatus {
+        scan_agent_with_status(cli, focus_id, "idle", cpu)
     }
 
     #[test]
@@ -290,6 +324,15 @@ mod tests {
         a
     }
 
+    fn hook_agent_with_event(
+        status: &str, cli: &str, focus_id: &str,
+        hook_event: Option<&str>, matcher: Option<&str>, mtime: Option<SystemTime>,
+    ) -> AgentStatus {
+        let mut a = hook_agent_with_matcher(status, cli, focus_id, matcher, mtime);
+        a.hook_event = hook_event.map(|s| s.into());
+        a
+    }
+
     #[test]
     fn stale_permission_prompt_cleared_when_process_active() {
         // Simulates macOS case: permission granted, PreToolUse hook didn't fire.
@@ -357,6 +400,28 @@ mod tests {
             Some("quota_warning"), Some(fresh_mtime),
         )];
         let scanned = vec![scan_agent("claude-code", "0x1234", 0.0)];
+
+        cross_validate(&mut agents, &scanned);
+        assert_eq!(agents[0].status, "needs-input");
+    }
+
+    #[test]
+    fn working_hook_upgraded_when_scanner_detects_waiting() {
+        let mut agents = vec![hook_agent("working", "codex", "0x1234", None)];
+        let scanned = vec![scan_agent_with_status("codex", "0x1234", "needs-input", 0.0)];
+
+        cross_validate(&mut agents, &scanned);
+        assert_eq!(agents[0].status, "needs-input");
+    }
+
+    #[test]
+    fn stale_codex_stop_wait_not_cleared() {
+        let old_mtime = SystemTime::now() - Duration::from_secs(90);
+        let mut agents = vec![hook_agent_with_event(
+            "needs-input", "codex", "0x1234",
+            Some("Stop"), None, Some(old_mtime),
+        )];
+        let scanned = vec![scan_agent("codex", "0x1234", 0.0)];
 
         cross_validate(&mut agents, &scanned);
         assert_eq!(agents[0].status, "needs-input");

--- a/src-tauri/src/notifier.rs
+++ b/src-tauri/src/notifier.rs
@@ -1,7 +1,13 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
 use tauri::AppHandle;
 use tauri_plugin_notification::NotificationExt;
 
 use crate::watcher::AgentStatus;
+
+const NEEDS_INPUT_REMINDER_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Events that can trigger a notification.
 #[derive(Debug, Clone)]
@@ -9,6 +15,10 @@ pub enum AgentEvent {
     NeedsInput {
         agent_name: String,
         /// Hook-provided reason: "permission_prompt", "idle_prompt", "elicitation_dialog", etc.
+        reason: Option<String>,
+    },
+    NeedsInputReminder {
+        agent_name: String,
         reason: Option<String>,
     },
 }
@@ -27,6 +37,11 @@ impl Notifier for SystemBeepNotifier {
             AgentEvent::NeedsInput { agent_name, reason } => {
                 let reason_str = reason.as_deref().unwrap_or("unknown");
                 log::info!("Agent '{}' needs input ({}) — playing alert", agent_name, reason_str);
+                play_system_beep();
+            }
+            AgentEvent::NeedsInputReminder { agent_name, reason } => {
+                let reason_str = reason.as_deref().unwrap_or("unknown");
+                log::info!("Agent '{}' still needs input ({}) — playing reminder", agent_name, reason_str);
                 play_system_beep();
             }
         }
@@ -59,6 +74,7 @@ impl Notifier for DesktopNotifier {
                     log::warn!("Desktop notification failed: {}", e);
                 }
             }
+            AgentEvent::NeedsInputReminder { .. } => {}
         }
     }
 }
@@ -95,6 +111,73 @@ impl Notifier for CompositeNotifier {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy)]
+struct ReminderState {
+    entered_at: Instant,
+    last_reminder_at: Option<Instant>,
+}
+
+#[derive(Default)]
+struct NeedsInputReminderTracker {
+    active: HashMap<String, ReminderState>,
+}
+
+impl NeedsInputReminderTracker {
+    fn collect_events(&mut self, old: &[AgentStatus], new: &[AgentStatus], now: Instant) -> Vec<AgentEvent> {
+        let active_ids: HashSet<String> = new.iter()
+            .filter(|agent| agent.status == "needs-input")
+            .map(|agent| agent.id.clone())
+            .collect();
+        self.active.retain(|id, _| active_ids.contains(id));
+
+        let mut events = Vec::new();
+
+        for agent in new.iter().filter(|agent| agent.status == "needs-input") {
+            let was_needs_input = old
+                .iter()
+                .find(|old_agent| old_agent.id == agent.id)
+                .map(|old_agent| old_agent.status == "needs-input")
+                .unwrap_or(false);
+
+            let entry = self.active.entry(agent.id.clone()).or_insert(ReminderState {
+                entered_at: now,
+                last_reminder_at: None,
+            });
+
+            if !was_needs_input {
+                *entry = ReminderState {
+                    entered_at: now,
+                    last_reminder_at: None,
+                };
+                events.push(AgentEvent::NeedsInput {
+                    agent_name: agent.name.clone(),
+                    reason: agent.hook_matcher.clone(),
+                });
+                continue;
+            }
+
+            let has_waited_long_enough = now.duration_since(entry.entered_at) >= NEEDS_INPUT_REMINDER_INTERVAL;
+            let reminder_due = entry.last_reminder_at
+                .map(|last| now.duration_since(last) >= NEEDS_INPUT_REMINDER_INTERVAL)
+                .unwrap_or(true);
+
+            if has_waited_long_enough && reminder_due {
+                entry.last_reminder_at = Some(now);
+                events.push(AgentEvent::NeedsInputReminder {
+                    agent_name: agent.name.clone(),
+                    reason: agent.hook_matcher.clone(),
+                });
+            }
+        }
+
+        events
+    }
+}
+
+static REMINDER_TRACKER: LazyLock<Mutex<NeedsInputReminderTracker>> = LazyLock::new(|| {
+    Mutex::new(NeedsInputReminderTracker::default())
+});
 
 fn play_system_beep() {
     std::thread::spawn(|| {
@@ -164,25 +247,28 @@ fn platform_beep() -> Result<(), String> {
     Ok(())
 }
 
-/// Compare old and new agent lists; fire notifications for transitions to needs-input.
-/// Uses `id` for identity matching so title/name changes don't retrigger alerts.
+/// Compare old and new agent lists; fire immediate notifications for
+/// transitions to needs-input, then periodic reminder beeps while the
+/// waiting state persists. Uses `id` for identity matching so title/name
+/// changes don't retrigger alerts.
 pub fn detect_and_notify(old: &[AgentStatus], new: &[AgentStatus], notifier: &dyn Notifier, app: Option<&AppHandle>) {
-    for agent in new {
-        if agent.status != "needs-input" {
-            continue;
-        }
-        let was_needs_input = old
-            .iter()
-            .find(|a| a.id == agent.id)
-            .map(|a| a.status == "needs-input")
-            .unwrap_or(false);
+    let mut tracker = REMINDER_TRACKER.lock().unwrap_or_else(|e| {
+        log::warn!("REMINDER_TRACKER mutex poisoned, recovering");
+        e.into_inner()
+    });
+    detect_and_notify_with_tracker(old, new, notifier, app, &mut tracker, Instant::now());
+}
 
-        if !was_needs_input {
-            notifier.notify(&AgentEvent::NeedsInput {
-                agent_name: agent.name.clone(),
-                reason: agent.hook_matcher.clone(),
-            }, app);
-        }
+fn detect_and_notify_with_tracker(
+    old: &[AgentStatus],
+    new: &[AgentStatus],
+    notifier: &dyn Notifier,
+    app: Option<&AppHandle>,
+    tracker: &mut NeedsInputReminderTracker,
+    now: Instant,
+) {
+    for event in tracker.collect_events(old, new, now) {
+        notifier.notify(&event, app);
     }
 }
 
@@ -219,40 +305,45 @@ mod tests {
     #[test]
     fn no_notification_when_already_needs_input() {
         let n = CountingNotifier(AtomicUsize::new(0));
+        let mut tracker = NeedsInputReminderTracker::default();
         let old = vec![agent("a", "needs-input")];
         let new = vec![agent("a", "needs-input")];
-        detect_and_notify(&old, &new, &n, None);
+        detect_and_notify_with_tracker(&old, &new, &n, None, &mut tracker, Instant::now());
         assert_eq!(n.0.load(Ordering::Relaxed), 0);
     }
 
     #[test]
     fn notification_on_transition_to_needs_input() {
         let n = CountingNotifier(AtomicUsize::new(0));
+        let mut tracker = NeedsInputReminderTracker::default();
         let old = vec![agent("a", "working")];
         let new = vec![agent("a", "needs-input")];
-        detect_and_notify(&old, &new, &n, None);
+        detect_and_notify_with_tracker(&old, &new, &n, None, &mut tracker, Instant::now());
         assert_eq!(n.0.load(Ordering::Relaxed), 1);
     }
 
     #[test]
     fn notification_for_new_agent_as_needs_input() {
         let n = CountingNotifier(AtomicUsize::new(0));
-        detect_and_notify(&[], &[agent("a", "needs-input")], &n, None);
+        let mut tracker = NeedsInputReminderTracker::default();
+        detect_and_notify_with_tracker(&[], &[agent("a", "needs-input")], &n, None, &mut tracker, Instant::now());
         assert_eq!(n.0.load(Ordering::Relaxed), 1);
     }
 
     #[test]
     fn no_notification_for_non_needs_input() {
         let n = CountingNotifier(AtomicUsize::new(0));
+        let mut tracker = NeedsInputReminderTracker::default();
         let old = vec![agent("a", "idle")];
         let new = vec![agent("a", "working")];
-        detect_and_notify(&old, &new, &n, None);
+        detect_and_notify_with_tracker(&old, &new, &n, None, &mut tracker, Instant::now());
         assert_eq!(n.0.load(Ordering::Relaxed), 0);
     }
 
     #[test]
     fn multiple_agents_only_transitioned_ones_notify() {
         let n = CountingNotifier(AtomicUsize::new(0));
+        let mut tracker = NeedsInputReminderTracker::default();
         let old = vec![
             agent("a", "working"),
             agent("b", "needs-input"),
@@ -263,7 +354,51 @@ mod tests {
             agent("b", "needs-input"),
             agent("c", "needs-input"),
         ];
-        detect_and_notify(&old, &new, &n, None);
+        detect_and_notify_with_tracker(&old, &new, &n, None, &mut tracker, Instant::now());
+        assert_eq!(n.0.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn reminder_fires_after_ten_seconds() {
+        let n = CountingNotifier(AtomicUsize::new(0));
+        let mut tracker = NeedsInputReminderTracker::default();
+        let start = Instant::now();
+        let waiting = vec![agent("a", "needs-input")];
+
+        detect_and_notify_with_tracker(&[], &waiting, &n, None, &mut tracker, start);
+        detect_and_notify_with_tracker(&waiting, &waiting, &n, None, &mut tracker, start + Duration::from_secs(10));
+
+        assert_eq!(n.0.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn reminder_repeats_every_ten_seconds() {
+        let n = CountingNotifier(AtomicUsize::new(0));
+        let mut tracker = NeedsInputReminderTracker::default();
+        let start = Instant::now();
+        let waiting = vec![agent("a", "needs-input")];
+
+        detect_and_notify_with_tracker(&[], &waiting, &n, None, &mut tracker, start);
+        detect_and_notify_with_tracker(&waiting, &waiting, &n, None, &mut tracker, start + Duration::from_secs(9));
+        detect_and_notify_with_tracker(&waiting, &waiting, &n, None, &mut tracker, start + Duration::from_secs(10));
+        detect_and_notify_with_tracker(&waiting, &waiting, &n, None, &mut tracker, start + Duration::from_secs(19));
+        detect_and_notify_with_tracker(&waiting, &waiting, &n, None, &mut tracker, start + Duration::from_secs(20));
+
+        assert_eq!(n.0.load(Ordering::Relaxed), 3);
+    }
+
+    #[test]
+    fn reminder_state_clears_when_agent_leaves_waiting() {
+        let n = CountingNotifier(AtomicUsize::new(0));
+        let mut tracker = NeedsInputReminderTracker::default();
+        let start = Instant::now();
+        let waiting = vec![agent("a", "needs-input")];
+        let working = vec![agent("a", "working")];
+
+        detect_and_notify_with_tracker(&[], &waiting, &n, None, &mut tracker, start);
+        detect_and_notify_with_tracker(&waiting, &working, &n, None, &mut tracker, start + Duration::from_secs(5));
+        detect_and_notify_with_tracker(&working, &waiting, &n, None, &mut tracker, start + Duration::from_secs(6));
+
         assert_eq!(n.0.load(Ordering::Relaxed), 2);
     }
 }

--- a/src-tauri/src/scanner/mod.rs
+++ b/src-tauri/src/scanner/mod.rs
@@ -170,6 +170,19 @@ impl Scanner {
                 }
             }
 
+            // For tmux panes: read the pane title set by the inner process via OSC
+            // escape sequences (e.g. Codex sets "Waiting...", "Thinking...", etc.).
+            // This overrides any outer terminal title from xdotool, which reflects
+            // tmux's own formatted title when set-titles is off — not the process title.
+            #[cfg(not(target_os = "windows"))]
+            if let Some(ref t) = terminal {
+                if t.kind == "tmux" && !t.focus_id.is_empty() {
+                    if let Some(pane_title) = read_tmux_pane_title(&t.focus_id) {
+                        p.window_title = Some(pane_title);
+                    }
+                }
+            }
+
             // Count direct child processes, excluding known background services
             // (MCP servers, worker services) that are always present.
             let child_count = count_children(p.pid, strategy.excluded_substrings());
@@ -500,6 +513,18 @@ fn detect_multiplexer_focus(pid: u32) -> Option<(String, String, String)> {
         }
     }
     None
+}
+
+/// Read the title of a tmux pane as set by the inner process via OSC escape
+/// sequences. Returns None if tmux is unavailable or the pane has no title.
+#[cfg(not(target_os = "windows"))]
+fn read_tmux_pane_title(pane_id: &str) -> Option<String> {
+    let output = std::process::Command::new("tmux")
+        .args(["display-message", "-t", pane_id, "-p", "#{pane_title}"])
+        .output()
+        .ok()?;
+    let title = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if title.is_empty() { None } else { Some(title) }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- **Hook scripts**: Codex `Stop` event now writes `needs-input` instead of `idle`, so waiting Codex agents are visible in the tray immediately
- **Heuristics**: Scanner-detected `needs-input` upgrades hook state with higher confidence; `is_genuine_needs_input` extracted to correctly classify Codex `Stop` and Gemini `Notification` events alongside Claude permission/elicitation prompts
- **Notifier**: `NeedsInputReminderTracker` fires an initial beep on transition to `needs-input`, then repeats every 10 s while the agent remains waiting — prompting the user without requiring manual tray inspection
- **Scanner**: Reads tmux pane title via `#{pane_title}` (set by inner process via OSC escape sequences) to override the outer terminal title, enabling reliable `Waiting...` detection for Codex running inside tmux

## Test plan

- [ ] Verify Codex in tmux transitions tray to `needs-input` when waiting for user input
- [ ] Confirm periodic beep sounds every ~10 s while agent stays in `needs-input`
- [ ] Confirm beep stops once agent resumes working
- [ ] Run `cargo test --manifest-path src-tauri/Cargo.toml` — all notifier and heuristics tests pass
- [ ] Verify Gemini and Claude permission prompts still behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)